### PR TITLE
Expose AI reasoning settings from config manager

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -179,7 +179,14 @@ class MainWindow(QMainWindow):
         # Używamy teraz paths.py
         self.project_dir = get_app_dir() # Use the path from paths.py
 
-        self.api_keys, self.current_models, self.settings, _ = config_manager.load_config()
+        self.ai_settings = {}
+        (
+            self.api_keys,
+            self.current_models,
+            self.settings,
+            self.ai_settings,
+            _,
+        ) = config_manager.load_config()
         self.s_original_text = ""
         self.s_current_style = "normal"
         self.api_clients_enum = {"OPENAI": 0, "ANTHROPIC": 1, "GEMINI": 2, "DEEPSEEK": 3} # Zgodnie z AutoIt Enum
@@ -700,7 +707,13 @@ class MainWindow(QMainWindow):
     def _update_gui_after_settings_change(self):
         """Aktualizuje GUI, np. tytuły paneli, po zmianie ustawień."""
         # Odświeżenie konfiguracji, którą przechowuje MainWindow
-        self.api_keys, self.current_models, self.settings, _ = config_manager.load_config()
+        (
+            self.api_keys,
+            self.current_models,
+            self.settings,
+            self.ai_settings,
+            _,
+        ) = config_manager.load_config()
 
         # Aktualizacja tytułów paneli API
         # Zakładamy, że self.api_grid_layout i groupboxy w nim istnieją
@@ -731,7 +744,13 @@ class MainWindow(QMainWindow):
         # Załaduj bieżącą konfigurację przed otwarciem dialogu
         # To zapewnia, że dialog zawsze startuje z najświeższymi danymi z pliku
         try:
-            current_keys, current_models_conf, current_settings, _ = config_manager.load_config()
+            (
+                current_keys,
+                current_models_conf,
+                current_settings,
+                current_ai_settings,
+                _,
+            ) = config_manager.load_config()
         except Exception as e:
             logger.error(f"Błąd ładowania konfiguracji przed otwarciem ustawień: {e}", exc_info=True)
             msg = QMessageBox(self)
@@ -930,7 +949,13 @@ class MainWindow(QMainWindow):
         # Ładujemy najnowsze klucze i modele przed każdym zapytaniem
         # aby uwzględnić zmiany dokonane w oknie ustawień bez restartu aplikacji
         try:
-            self.api_keys, self.current_models, self.settings, _ = config_manager.load_config()
+            (
+                self.api_keys,
+                self.current_models,
+                self.settings,
+                self.ai_settings,
+                _,
+            ) = config_manager.load_config()
             logger.debug("Przeładowano konfigurację API przed rozpoczęciem zapytań.")
         except Exception as e:
             error_message = f"Błąd podczas przeładowania konfiguracji API: {e}"

--- a/gui/settings_dialog.py
+++ b/gui/settings_dialog.py
@@ -234,7 +234,7 @@ if __name__ == '__main__':
     # Załaduj przykładową lub pustą konfigurację do testów
     # W rzeczywistej aplikacji te dane przyszłyby z MainWindow
     try:
-        keys, models_conf, settings_conf, _ = config_manager.load_config()
+        keys, models_conf, settings_conf, ai_settings, _ = config_manager.load_config()
     except Exception as e:
         print(f"Błąd ładowania configu: {e}, używam domyślnych.")
         keys = {"OpenAI": "", "Anthropic": "", "Gemini": "", "DeepSeek": ""}

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ def check_first_run():
         log_debug_info()
         
         # Ładuje konfigurację
-        api_keys, models, settings, new_config = config_manager.load_config()
+        api_keys, models, settings, ai_settings, new_config = config_manager.load_config()
         logging.info("Wczytano konfigurację kluczy API")
         logging.info(f"Wczytane modele: {models}")
         logging.info(f"Czy nowa konfiguracja: {new_config}")

--- a/main_console.py
+++ b/main_console.py
@@ -42,7 +42,7 @@ def main():
     
     try:
         # Load config
-        api_keys, models, settings, new_config = config_manager.load_config()
+        api_keys, models, settings, ai_settings, new_config = config_manager.load_config()
         
         if not api_keys or not any(api_keys.values()):
             print("ERROR: No API keys configured")

--- a/main_modern.py
+++ b/main_modern.py
@@ -47,6 +47,7 @@ class ModernTextCorrector(ctk.CTk):
         self.api_keys = {}
         self.models = {}
         self.settings = {}
+        self.ai_settings = {}
         
         # Interfejs
         self.setup_ui()
@@ -143,7 +144,13 @@ class ModernTextCorrector(ctk.CTk):
     def load_config(self):
         """Ładuje konfigurację API."""
         try:
-            self.api_keys, self.models, self.settings, _ = config_manager.load_config()
+            (
+                self.api_keys,
+                self.models,
+                self.settings,
+                self.ai_settings,
+                _,
+            ) = config_manager.load_config()
             
             if not any(self.api_keys.values()):
                 self.update_status("⚠️ Brak konfiguracji API - skonfiguruj w ustawieniach")

--- a/main_pyside.py
+++ b/main_pyside.py
@@ -106,7 +106,7 @@ def check_first_run():
         log_debug_info()
         
         # Ładuje konfigurację
-        api_keys, models, settings, new_config = config_manager.load_config()
+        api_keys, models, settings, ai_settings, new_config = config_manager.load_config()
         logging.info(f"Wczytane klucze API: {api_keys}")
         logging.info(f"Wczytane modele: {models}")
         logging.info(f"Czy nowa konfiguracja: {new_config}")


### PR DESCRIPTION
## Summary
- return AI reasoning settings from `config_manager.load_config` with consistent defaults and fallback handling
- propagate `ai_settings` through the CustomTkinter UI so the settings dialog loads and saves reasoning options without rereading the file
- adjust other entry points to unpack the extended configuration tuple

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68cb0c4f245c8324892f6381252883cb